### PR TITLE
Update for Laravel 3.2

### DIFF
--- a/Blade.tmLanguage
+++ b/Blade.tmLanguage
@@ -654,7 +654,8 @@
         <key>blade-compiler-tags</key>
         <dict>
             <key>begin</key>
-            <string>\@\b(include|section|layout|yield|if|elseif|foreach|forelse|for|while|render|unless)\b(?=(|\s*|)\()</string>
+            <!-- <string>\@\b(include|section|layout|yield|if|elseif|foreach|forelse|for|while|render|unless)\b(?=(|\s*|)\()</string> -->
+            <string>\@\b(.+)\b(?=(|\s*|)\()</string>
             <key>beginCaptures</key>
             <dict>
                 <key>0</key>


### PR DESCRIPTION
Hi,

I added support for Laravel 3.2's Blade::extend() method, which adds any string as a blade compiler.

``` html
@widget('test')
```

Signed-off-by: Ben Corlett bencorlett@me.com
