### PR TITLE
Fixed coloring of nested static calls

### DIFF
--- a/Blade.tmLanguage
+++ b/Blade.tmLanguage
@@ -795,7 +795,7 @@
                 </dict>
             </dict>
             <key>match</key>
-            <string>\b(.+?)\b(::)\b(.+?)\b(\()</string>
+            <string>\b([^\s]+?)\b(::)\b(.+?)\b(\()</string>
         </dict>
 
         <!-- Blade Compiler Closing Tags -->


### PR DESCRIPTION
When you had e.g.:

`{{ $errors->first('field', HTML::span(':message')) }}`

The front up to the HTML static call would be colored as the classname.
