### PR TITLE
Changed DOCTYPE validation to case-insensitive

### DIFF
--- a/Blade.tmLanguage
+++ b/Blade.tmLanguage
@@ -146,7 +146,7 @@
             <array>
                 <dict>
                     <key>begin</key>
-                    <string>(DOCTYPE)</string>
+                    <string>(?i:DOCTYPE)</string>
                     <key>captures</key>
                     <dict>
                         <key>1</key>


### PR DESCRIPTION
Hi Medalink

Thanks for you great Blade syntax hightlighting for Sublime Text 2. One minor bug I've encounted was the DOCTYPE validation which I've changed to case-insensitive as per http://dev.w3.org/html5/spec/single-page.html#the-doctype

/Pephers
