### PR TITLE
add laravel4 template syntax

### DIFF
--- a/laravel-blade.tmLanguage
+++ b/laravel-blade.tmLanguage
@@ -150,7 +150,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\@(end(forelse|foreach|section|for|while|if|unless)|render(_each)|parent|yield_section|empty|else|end)</string>
+			<string>\@(end(forelse|foreach|each|section|for|while|if|unless)|render(_each)|each|parent|yield_section|show|empty|else|stop)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
Laravel4 blade syntax has changed slightly. @section no longer ends with @endsection or @yield_section but with @stop and @show.  @layout was also changed to @extends. This modification will allow compatibility between both L3 and L4.
