### PR TITLE
add laravel4 template syntax

### DIFF
--- a/laravel-blade-raw.JSON-tmLanguage
+++ b/laravel-blade-raw.JSON-tmLanguage
@@ -91,7 +91,7 @@
         },
         {
             "comment": "Laravel Blade Stock Compiler Closure",
-            "begin": "\\@(end(forelse|foreach|section|for|while|if|unless)|render(_each)|parent|yield_section|empty|else|stop)",
+            "begin": "\\@(end(forelse|foreach|each|section|for|while|if|unless)|render(_each)|parent|yield_section|show|empty|else|stop)",
             "beginCaptures": {
                 "0": {
                     "name": "support.constant.laravel-blade"


### PR DESCRIPTION
Laravel4 blade syntax has changed slightly. @section no longer ends with @endsection or @yield_section but with @stop and @show.  @layout was also changed to @extends. This modification will allow compatibility between both L3 and L4.
