### PR TITLE
Add support for triple braces {{{ }}}

### DIFF
--- a/laravel-blade.tmLanguage
+++ b/laravel-blade.tmLanguage
@@ -41,7 +41,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\{\{-?</string>
+			<string>\{\{\{?-?</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -53,7 +53,7 @@
 			<key>comment</key>
 			<string>Catches the remainder.</string>
 			<key>end</key>
-			<string>-?\}\}</string>
+			<string>-?\}?\}\}</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
L4 uses double braces `{{ }}` to escape data and triple braces `{{{ }}}` for raw data.
