### PR TITLE
Fix for ST3 Build 3103 - fixes #89

### DIFF
--- a/blade.sublime-syntax
+++ b/blade.sublime-syntax
@@ -38,7 +38,7 @@ contexts:
             1: constant.other.inline-data.html
             2: constant.other.inline-data.html
           push:
-            - meta_scope: meta.embedded.line.php
+            - meta_scope: source.php
             - meta_content_scope: source.php
             - match: '\)(?!.*\))'
               pop: true
@@ -49,7 +49,7 @@ contexts:
             0: entity.name.tag.block.any.html
             1: constant.other.inline-data.html
             2: constant.other.inline-data.html
-          pop: true
+          pop: false
 
         - match: '(\s{0}|^)(\@)\b(.+)\b(?=(|\s*|)\()'
           captures:


### PR DESCRIPTION
This may be a hack, rather than a fix, as I don't know the SublimeText syntax highlight functionality very well, but I tested it againt the `test.blade.php` file and everything looks okay.

Before on the left, after the changes on the right...

![example](https://cloud.githubusercontent.com/assets/340752/13049082/4a857fe0-d3e2-11e5-89dc-333a1055fabd.png)

Thoughts?