### PR TITLE
Fix PHP tags highlighting

### DIFF
--- a/blade.sublime-syntax
+++ b/blade.sublime-syntax
@@ -81,27 +81,25 @@ contexts:
               pop: true
 
         - match: '<\?(?i:php|=)?(?![^?]*\?>)'
-          captures:
-            0: punctuation.section.embedded.begin.php
-          push:
+          scope: punctuation.section.embedded.begin.php
+          push: 
+            - meta_content_scope: source.php
             - meta_scope: meta.embedded.block.php
-            - meta_content_scope: source.php
-            - match: (\?)>
-              captures:
-                0: punctuation.section.embedded.end.php
-                1: source.php
-              pop: true
             - include: 'scope:source.php'
+          with_prototype:
+          - match: (?=\?>)(\?>)
+            captures:
+              0: punctuation.section.embedded.end.php
+            pop: true
 
-        - match: <\?(?i:php|=)?
-          captures:
-            0: punctuation.section.embedded.begin.php
-          push:
-            - meta_scope: meta.embedded.line.php
+        - match: '<\?(?i:php|=)?'
+          scope: punctuation.section.embedded.begin.php
+          push: 
             - meta_content_scope: source.php
-            - match: (\?)>
-              captures:
-                0: punctuation.section.embedded.end.php
-                1: source.php
-              pop: true
+            - meta_scope: meta.embedded.line.php
             - include: 'scope:source.php'
+          with_prototype:
+          - match: (?=\?>)(\?>)
+            captures:
+              0: punctuation.section.embedded.end.php
+            pop: true

--- a/test.blade
+++ b/test.blade
@@ -133,3 +133,12 @@ This comment will not be in the rendered HTML
 
 @foo('bar', 'baz')
     @datetime($var)
+
+<?php echo $name; ?>
+<?= $name; ?>
+
+<?php 
+    foreach (range(1, 10) as $number) {
+        echo $number;
+    }
+?>

--- a/test.blade.php
+++ b/test.blade.php
@@ -199,3 +199,12 @@ You don't have permission!
 
 @foo('bar', 'baz')
     @datetime($var)
+
+<?php echo $name; ?>
+<?= $name; ?>
+
+<?php 
+    foreach (range(1, 10) as $number) {
+        echo $number;
+    }
+?>


### PR DESCRIPTION
This bug was there from the very start and the PHP tags weren't highlighting properly.

### laravel-blade ReadMe preview
![capture](https://cloud.githubusercontent.com/assets/8646770/15656688/bd9a4f46-265e-11e6-8d16-d895cac01166.PNG)

## PHP Block
![fix1](https://cloud.githubusercontent.com/assets/8646770/15656603/0ed90c5e-265e-11e6-8500-c49b6da76d99.png)

## PHP Line
![fix2](https://cloud.githubusercontent.com/assets/8646770/15656604/0f0c0398-265e-11e6-99f9-0cee014f4c46.png)