### PR TITLE
Add shortcode from Blade Wordpress Plugin

### DIFF
--- a/blade.sublime-syntax
+++ b/blade.sublime-syntax
@@ -78,7 +78,7 @@ contexts:
               0: punctuation.section.embedded.end.php
             pop: true
 
-        - match: '(\s{0}|^)(\@)\b(debug|embed|macrodef|set|unset|if|elseif|forelse|foreach|for|while|extends|unless|each|yield|lang|choice|section|include|render|block|can|cannot|inject|partial|hasSection|elsecan|elsecannot|stack|push|layout|continue|break|minify|macro|servers|task|hipchat|slack)\b(?=(|\s*|)\()'
+        - match: '(\s{0}|^)(\@)\b(debug|embed|macrodef|set|unset|if|elseif|forelse|foreach|for|while|extends|unless|each|yield|lang|choice|section|include|render|block|can|cannot|inject|partial|hasSection|elsecan|elsecannot|stack|push|layout|continue|break|minify|macro|servers|task|hipchat|slack|wpquery|wpposts|acfrepeater)\b(?=(|\s*|)\()'
           captures:
             0: punctuation.section.embedded.php
             2: constant.other.inline-data.html
@@ -90,7 +90,7 @@ contexts:
               pop: true
             - include: 'scope:source.php'
 
-        - match: '(\s{0}|^)(\@)\b(breakpoint|endmacro|endembed|empty|endif|endforelse|endforeach|endfor|endwhile|else|endunless|show|stop|endblock|endpartial|continue|break|endsection|parent|overwrite|endcan|endcannot|append|endpush|markdown|endmarkdown|endminify|endtask|setup|after|endsetup|endafter)\b'
+        - match: '(\s{0}|^)(\@)\b(breakpoint|endmacro|endembed|empty|endif|endforelse|endforeach|endfor|endwhile|else|endunless|show|stop|endblock|endpartial|continue|break|endsection|parent|overwrite|endcan|endcannot|append|endpush|markdown|endmarkdown|endminify|endtask|setup|after|endsetup|endafter|wpempty|wpend|acfend)\b'
           scope: custom.compiler.blade.php
           captures:
             0: punctuation.section.embedded.php


### PR DESCRIPTION
The [Blade Wordpress Plugin](https://it.wordpress.org/plugins/blade/) use specific snippet to blade:
* `wpquery`
* `wpposts`
* `acfrepeater`
* `wpempty`
* `wpend`
* `acfend`

The Loop
```blade
@wpposts
    <a href="{{the_permalink()}}">{{the_title()}}</a><br>
@wpempty
    <p>404</p>
@wpend
```
Turns into...
```html
<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
    <a href="<?php the_permalink() ?>"><?php the_title() ?></a><br>
<?php endwhile; else: ?>
    <p>404</p>
<?php endif; ?>
```

WP Query
```blade
<ul>
@wpquery(array('post_type' => 'post'))
    <li><a href="{{the_permalink()}}">{{the_title()}}</a></li>
@wpempty
    <li>{{ __('Sorry, no posts matched your criteria.') }}</li>
@wpend
</ul>
```
Turns into....
```html
<ul>
<?php $query = new WP_Query( array('post_type' => 'post') ); ?>
<?php if ( $query->have_posts() ) : ?>
    <?php while ( $query->have_posts() ) : $query->the_post(); ?>
        <li><a href="<?php the_permalink() ?>"> <?php the_title() ?> </a></li>
    <?php endwhile; ?>
<?php else : ?>
    <li><?php _e('Sorry, no posts matched your criteria.') ?></li>
<?php endif; wp_reset_postdata(); ?>
</ul>
```

Advanced Custom Fields
```blade
<ul>
    @acfrepeater('images')
        <li>{{ get_sub_field( 'image' ) }}</li>
    @acfend
</ul>
```
Turns into...
```html
<ul>
    <?php if( get_field( 'images' ) ): ?>
        <?php while( has_sub_field( 'images' ) ): ?>
            <li><img src="<?php the_sub_field( 'image' ) ?>" /></li>
        <?php endwhile; ?>
    <?php endif; ?>
</ul>
```

Check this for all infos: https://it.wordpress.org/plugins/blade/