### PR TITLE
Fixed @guest/@auth support

### DIFF
--- a/blade.sublime-syntax
+++ b/blade.sublime-syntax
@@ -90,7 +90,7 @@ contexts:
               pop: true
             - include: 'scope:source.php'
 
-        - match: '(\s{0}|^)(\@)\b(acfend|after|append|break|breakpoint|continue|default|else|empty|endswitch|endafter|endblock|endcan|endcannot|endcomponent|endembed|endfor|endforeach|endforelse|endif|endmacro|endmarkdown|endminify|endpartial|endpush|endsection|endsetup|endslot|endstory|endtask|endunless|endwhile|markdown|overwrite|parent|setup|show|stop|verbatim|endverbatim|wpempty|wpend|wpquery)\b'
+        - match: '(\s{0}|^)(\@)\b(acfend|after|append|auth|break|breakpoint|continue|default|else|empty|endswitch|endafter|endauth|endblock|endcan|endcannot|endcomponent|endembed|endfor|endforeach|endforelse|endguest|endif|endmacro|endmarkdown|endminify|endpartial|endpush|endsection|endsetup|endslot|endstory|endtask|endunless|endwhile|guest|markdown|overwrite|parent|setup|show|stop|verbatim|endverbatim|wpempty|wpend|wpquery)\b'
           scope: custom.compiler.blade.php
           captures:
             0: punctuation.section.embedded.php


### PR DESCRIPTION
@guest and @auth both have the optional parameter's option, which caused them not to be highlighted if they weren't given. This makes sure it works for both with or without them

Signed-off-by: Kaleb Klein <klein.jae@gmail.com>