### PR TITLE
Fix matching on complex @if directives

### DIFF
--- a/blade.sublime-syntax
+++ b/blade.sublime-syntax
@@ -86,7 +86,7 @@ contexts:
           push:
             - meta_scope: custom.compiler.blade.php
             - meta_content_scope: source.php.blade
-            - match: '(?<=\))'
+            - match: '(?<=$)'
               pop: true
             - include: 'scope:source.php'
 


### PR DESCRIPTION
Fix matching on `@if` statement containing more than one closing paren `)`, where syntax highlight would only show through that first closing paren.

This changes the syntax highlighting from this

![image](https://user-images.githubusercontent.com/43112/29289343-ada2db7c-8101-11e7-98c8-3894d08151ce.png)

to this

![image](https://user-images.githubusercontent.com/43112/29289347-af5fca10-8101-11e7-934d-419c3d9d7f63.png)
