### PR TITLE
Fix complex directive matching

### DIFF
--- a/blade.sublime-syntax
+++ b/blade.sublime-syntax
@@ -78,7 +78,19 @@ contexts:
               0: punctuation.section.embedded.end.php
             pop: true
 
-        - match: '(\s{0}|^)(\@)\b(acfrepeater|auth|block|break|can|cannot|choice|case|component|continue|debug|each|elsecan|elsecannot|elseif|embed|extends|for|foreach|forelse|guest|hasSection|hipchat|if|isset|include|includeIf|includeWhen|inject|lang|layout|macro|macrodef|minify|partial|php|push|render|section|servers|set|slack|slot|stack|story|switch|task|unless|unset|while|wpposts|yield)\b(?=(|\s*|)\()'
+        - match: '(\s{0}|^)(\@)\b(acfrepeater|block|break|can|cannot|choice|component|continue|debug|each|elsecan|elsecannot|elseif|embed|extends|for|foreach|forelse|hasSection|hipchat|if|include|includeWhen|inject|lang|layout|macro|macrodef|minify|partial|php|push|render|section|servers|set|slack|slot|stack|story|task|unless|unset|while|wpposts|yield)\b(?=(|\s*|)\(\()'
+          captures:
+            0: punctuation.section.embedded.php
+            2: constant.other.inline-data.html
+            3: entity.name.tag.block.any.html
+          push:
+            - meta_scope: custom.compiler.blade.php
+            - meta_content_scope: source.php.blade
+            - match: '(?<=\)\))'
+              pop: true
+            - include: 'scope:source.php'
+
+        - match: '(\s{0}|^)(\@)\b(acfrepeater|block|break|can|cannot|choice|component|continue|debug|each|elsecan|elsecannot|elseif|embed|extends|for|foreach|forelse|hasSection|hipchat|if|include|includeWhen|inject|lang|layout|macro|macrodef|minify|partial|php|push|render|section|servers|set|slack|slot|stack|story|task|unless|unset|while|wpposts|yield)\b(?=(|\s*|)\()'
           captures:
             0: punctuation.section.embedded.php
             2: constant.other.inline-data.html
@@ -90,7 +102,7 @@ contexts:
               pop: true
             - include: 'scope:source.php'
 
-        - match: '(\s{0}|^)(\@)\b(acfend|after|append|auth|break|breakpoint|continue|default|else|empty|endswitch|endafter|endauth|endblock|endcan|endcannot|endcomponent|endembed|endempty|endfor|endforeach|endforelse|endguest|endif|endisset|endmacro|endmarkdown|endminify|endpartial|endpush|endsection|endsetup|endslot|endstory|endtask|endunless|endwhile|guest|markdown|overwrite|parent|setup|show|stop|verbatim|endverbatim|wpempty|wpend|wpquery)\b'
+        - match: '(\s{0}|^)(\@)\b(acfend|after|append|break|breakpoint|continue|else|empty|endafter|endblock|endcan|endcannot|endcomponent|endembed|endfor|endforeach|endforelse|endif|endmacro|endmarkdown|endminify|endpartial|endpush|endsection|endsetup|endslot|endstory|endtask|endunless|endwhile|markdown|overwrite|parent|setup|show|stop|verbatim|endverbatim|wpempty|wpend|wpquery)\b'
           scope: custom.compiler.blade.php
           captures:
             0: punctuation.section.embedded.php

--- a/blade.sublime-syntax
+++ b/blade.sublime-syntax
@@ -78,7 +78,7 @@ contexts:
               0: punctuation.section.embedded.end.php
             pop: true
 
-        - match: '(\s{0}|^)(\@)\b(acfrepeater|block|break|can|cannot|choice|component|continue|debug|each|elsecan|elsecannot|elseif|embed|extends|for|foreach|forelse|hasSection|hipchat|if|include|includeWhen|inject|lang|layout|macro|macrodef|minify|partial|php|push|render|section|servers|set|slack|slot|stack|story|task|unless|unset|while|wpposts|yield)\b(?=(|\s*|)\(\()'
+        - match: '(\s{0}|^)(\@)\b(acfrepeater|auth|block|break|can|cannot|choice|case|component|continue|debug|each|elsecan|elsecannot|elseif|embed|extends|for|foreach|forelse|guest|hasSection|hipchat|if|isset|include|includeIf|includeWhen|inject|lang|layout|macro|macrodef|minify|partial|php|push|render|section|servers|set|slack|slot|stack|story|switch|task|unless|unset|while|wpposts|yield)\b(?=(|\s*|)\(\()'
           captures:
             0: punctuation.section.embedded.php
             2: constant.other.inline-data.html
@@ -90,7 +90,7 @@ contexts:
               pop: true
             - include: 'scope:source.php'
 
-        - match: '(\s{0}|^)(\@)\b(acfrepeater|block|break|can|cannot|choice|component|continue|debug|each|elsecan|elsecannot|elseif|embed|extends|for|foreach|forelse|hasSection|hipchat|if|include|includeWhen|inject|lang|layout|macro|macrodef|minify|partial|php|push|render|section|servers|set|slack|slot|stack|story|task|unless|unset|while|wpposts|yield)\b(?=(|\s*|)\()'
+        - match: '(\s{0}|^)(\@)\b(acfrepeater|auth|block|break|can|cannot|choice|case|component|continue|debug|each|elsecan|elsecannot|elseif|embed|extends|for|foreach|forelse|guest|hasSection|hipchat|if|isset|include|includeIf|includeWhen|inject|lang|layout|macro|macrodef|minify|partial|php|push|render|section|servers|set|slack|slot|stack|story|switch|task|unless|unset|while|wpposts|yield)\b(?=(|\s*|)\()'
           captures:
             0: punctuation.section.embedded.php
             2: constant.other.inline-data.html
@@ -102,7 +102,7 @@ contexts:
               pop: true
             - include: 'scope:source.php'
 
-        - match: '(\s{0}|^)(\@)\b(acfend|after|append|break|breakpoint|continue|else|empty|endafter|endblock|endcan|endcannot|endcomponent|endembed|endfor|endforeach|endforelse|endif|endmacro|endmarkdown|endminify|endpartial|endpush|endsection|endsetup|endslot|endstory|endtask|endunless|endwhile|markdown|overwrite|parent|setup|show|stop|verbatim|endverbatim|wpempty|wpend|wpquery)\b'
+        - match: '(\s{0}|^)(\@)\b(acfend|after|append|auth|break|breakpoint|continue|default|else|empty|endswitch|endafter|endauth|endblock|endcan|endcannot|endcomponent|endembed|endempty|endfor|endforeach|endforelse|endguest|endif|endisset|endmacro|endmarkdown|endminify|endpartial|endpush|endsection|endsetup|endslot|endstory|endtask|endunless|endwhile|guest|markdown|overwrite|parent|setup|show|stop|verbatim|endverbatim|wpempty|wpend|wpquery)\b'
           scope: custom.compiler.blade.php
           captures:
             0: punctuation.section.embedded.php

--- a/test.blade.php
+++ b/test.blade.php
@@ -391,3 +391,17 @@ This comment will not be in the rendered HTML
     @default
         <p>Default</p>
 @endswitch
+
+{{-- Complex conditional --}}
+@if(($x == true) && ($y == false)) 
+    <a>foo</a>
+@endif
+
+{{-- Single line if statement --}}
+@if($foo === true) <p>Text</p> @endif
+
+{{-- Quoted blade directive matching --}}
+<p class="first-class @if($x==true) second-class @endif">Text</p>
+
+{{-- Complex conditional inline --}}
+<p class="first-class @if(($x == true) && ($y == "yes")) second-class @endif">Text</p>


### PR DESCRIPTION
Alright, this is a correction to PR #150. Please test against the additional blocks in test.blade.php and against your own blade code for proper syntax highlighting.

### The bad fix

My first attempt replaced the "ending" match that would end the blade directive from a single closed parentheses to the end of the line (changing `(?<=\))` to `(?<=$)`).

This broke other highlighting when the directive was used inside quotes, such as conditionally setting a property in a DOM element.

### This fix
After trying a ton of options that all didn't work, it seems that the best (and maybe only?) way to support directives with more complex code is to duplicate the match block and tweak the new block to support two leading/closing parenthesis on the directive.

The existing (unchanged) match is:

```
- match: '(\s{0}|^)(\@)\b(list|of|directives)\b(?=(|\s*|)\()'
...
push:
  - match: '(?<=\))'
```

And the new block 

```
- match: '(\s{0}|^)(\@)\b(list|of|directives)\b(?=(|\s*|)\(\()'
...
push:
  - match: '(?<=\)\))'
```

Note the additional parentheses at the end of `match` and `push > match` regular expressions. 

Here's what it looks like on the four new test blocks:

![sublime_text_2017-08-17_13-14-38](https://user-images.githubusercontent.com/43112/29427607-f5572716-834f-11e7-9fff-ddd2e954fd00.png)

If anyone has issues with this version, let me know and we'll work on them here in the PR.