### PR TITLE
Fix @php highlighting of the null coalescing and shorthand ternary operators

### DIFF
--- a/blade.sublime-syntax
+++ b/blade.sublime-syntax
@@ -59,8 +59,8 @@ contexts:
                 0: punctuation.section.embedded.end.blade
               pop: true
             - include: 'scope:source.php'
-            
-        - match: '((\s{0}|^)(@)(php)(?![^?]*\(*\))|<\?(?i:php|=)?)(?![^?]*\?>)'
+
+        - match: '((\s{0}|^)(@)(php)(?!.*\(*\))|<\?(?i:php|=)?)(?![^?]*\?>)'
           scope: punctuation.section.embedded.begin.php
           captures:
               0: punctuation.section.embedded.begin.php

--- a/test.blade.php
+++ b/test.blade.php
@@ -41,6 +41,8 @@ Hello, {{{ $name }}}.
 {{-- Inline PHP --}}
 <div class="container">
     @php(custom_function())
+    @php($bool = $var ?? false)
+    @php($bool = $bool ?: true)
 </div>
 
 @include('footer')


### PR DESCRIPTION
Before PR:
![image](https://user-images.githubusercontent.com/11477505/59157943-11e1b480-8abc-11e9-89ce-73eaad555ef2.png)
After PR:
![image](https://user-images.githubusercontent.com/11477505/59157955-1c03b300-8abc-11e9-9817-ce4819db1296.png)
