### PR TITLE
Remove invalid `pop` directives

### DIFF
--- a/blade.sublime-syntax
+++ b/blade.sublime-syntax
@@ -120,7 +120,6 @@ contexts:
             0: punctuation.section.embedded.php
             2: constant.other.inline-data.html
             3: entity.name.tag.block.any.html
-          pop: false
 
         - match: '(\s{0}|^)(\@)\b([a-zA-Z_]+)\b(?=(|\s*|)\()'
           captures:
@@ -138,4 +137,3 @@ contexts:
           captures:
             0: support.function
             2: constant.other.inline-data.html
-          pop: false


### PR DESCRIPTION
`pop` only accepts `true` or an integer larger than zero.

The invalid directives break the syntax in pre-release builds of Sublime. The syntax would not even be loaded. This will ensure compatibility going forward.