### PR TITLE
Fix attribute value scopes after directives

### DIFF
--- a/Syntaxes/HTML (Blade).sublime-syntax
+++ b/Syntaxes/HTML (Blade).sublime-syntax
@@ -83,6 +83,15 @@ contexts:
         3: source.css.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+  tag-generic-attribute:
+    # fixes: https://github.com/Medalink/laravel-blade/issues/196
+    - meta_prepend: true
+    - match: =
+      scope: punctuation.separator.key-value.html
+      push:
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
   tag-event-attribute-value:
     # note: only needed for backward compatibility with ST4143
     - meta_include_prototype: false

--- a/tests/syntax_test_blade.blade.php
+++ b/tests/syntax_test_blade.blade.php
@@ -1192,3 +1192,11 @@
 {{--                                      ^ punctuation.section.group.end.js --}}
 {{--                                       ^ punctuation.definition.string.end.html --}}
 {{--                                        ^ meta.tag punctuation.definition.tag.end.html --}}
+
+    <button @click="alert('Hello World!')">Say Hi</button>
+{{--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag --}}
+{{--        ^^^^^^ meta.embedded.blade source.blade meta.directive.blade variable.function.blade --}}
+{{--              ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.html --}}
+{{--              ^ punctuation.separator.key-value.html --}}
+{{--               ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html --}}
+{{--                                      ^ punctuation.definition.tag.end.html --}}


### PR DESCRIPTION
Fixes #196

This commit adds a fallback pattern to `generic-attribute-values` context in order to correctly scope attribute values, even if no attribute names have been consumed before.

The `@click` directive is not scoped as attribute name due to a design issue of basic HTML syntax with regards to `prototype` handling within tags. Hence HTML does not match/consume the value assignment via `=`.